### PR TITLE
[SPARK-48311][SQL] Fix nested pythonUDF in groupBy and aggregate in Binding Exception

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ExtractPythonUDFs.scala
@@ -124,7 +124,7 @@ object ExtractGroupingPythonUDFFromAggregate extends Rule[LogicalPlan] {
       }
     }
     val aggExpr = agg.aggregateExpressions.map { expr =>
-      expr.transformUp {
+      expr.transformDown {
         // PythonUDF over aggregate was pull out by ExtractPythonUDFFromAggregate.
         // PythonUDF here should be either
         // 1. Argument of an aggregate function.

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -17,8 +17,10 @@
 
 package org.apache.spark.sql.execution.python
 
+import scala.collection.Seq
+
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
-import org.apache.spark.sql.functions.{array, col, count, transform}
+import org.apache.spark.sql.functions.{array, col, count, countDistinct, transform}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.LongType
 
@@ -137,6 +139,36 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
       val df = newTable.as("t1").join(
         newTable.as("t2"), col("t1.new_column") === col("t2.new_column"))
       checkAnswer(df, Row(0, 1, 1, 0, 1, 1))
+    }
+  }
+
+  test("SPARK-48311: Nested pythonUDF in groupBy and aggregate") {
+    assume(shouldTestPythonUDFs)
+    withTempView("testCacheTable") {
+      // Define data
+      val data = Seq(Some("1")).toDF("col3")
+      data.createOrReplaceTempView("testCacheTable")
+      val df = spark.sql("SELECT DISTINCT col3 FROM testCacheTable")
+      // Define groupBy columns
+      val groupByCols = Seq("col4", "col5", "col3")
+
+      val pythonTestUDF1 = TestPythonUDF(name = "pyUDF1")
+      val pythonTestUDF2 = TestPythonUDF(name = "pyUDF2")
+      // Apply transformations
+      val df1 = df
+        .withColumn("col4", pythonTestUDF1(df("col3")))
+      val resultPython = df1.withColumn("col5", pythonTestUDF2(df1("col4")))
+        .groupBy(groupByCols.head, groupByCols.tail: _*).agg(countDistinct("col5").alias("col6"))
+
+      val scalaTestUDF = TestScalaUDF(name = "scalaUDF")
+      val scalaTestUDF1 = TestScalaUDF(name = "scalaUDF1")
+      // Apply transformations
+      val df2 = df
+        .withColumn("col4", scalaTestUDF(df("col3")))
+      val resultScala = df2.withColumn("col5", scalaTestUDF1(df2("col4")))
+        .groupBy(groupByCols.head, groupByCols.tail: _*).agg(countDistinct("col5").alias("col6"))
+
+      checkAnswer(resultScala, resultPython)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.python
 
-import scala.collection.Seq
-
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.functions.{array, col, count, countDistinct, transform}
 import org.apache.spark.sql.test.SharedSparkSession


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
While replacing canonicalized python udf in aggregateExpressions we are proposing it to do transformDown instead of transformUp. This will insure that correct canonicalized python udf will used from groupingExpressions.



### Why are the changes needed?

This is a bug, because groupingExpressions does transformDown and aggregateExpressions does transformUp which led to add new canonicalized python udfs.

details can be found: https://docs.google.com/document/d/1RXOOCsaFU-E1ZmXJnSrJ2jdRgYQgGAVxDPeFNNaoB1M/edit?usp=sharing 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
unit test


### Was this patch authored or co-authored using generative AI tooling?
No
